### PR TITLE
readme rewrite + docs cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ lazy-lock.json
 .luarc.json
 zsh/.zshrc.local
 
-# machine-local / private config overlays — never tracked
+# machine-local / private config overlays - never tracked
 nvim/lua/private/
 
 # LaTeX build artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-Personal dotfiles for macOS. Source-based (no stow/symlinks) — tools reference configs directly from `~/dotfiles/`. No build or install scripts; tools are installed externally via Homebrew.
+Personal dotfiles for macOS. Source-based (no stow/symlinks) - tools reference configs directly from `~/dotfiles/`. No build or install scripts; tools are installed externally via Homebrew.
+
+Docs style: plain human voice, never use em dashes (they read as AI-generated); explain tools instead of name-dropping them.
 
 ## Structure
 
-- **nvim/** — Neovim config (Lua-based, lazy.nvim plugin manager); keybinding reference in `nvim/KEYMAPS.md`
-- **zsh/.zshrc** — Zsh shell config (Oh My Zsh, Starship prompt, modern CLI tools)
-- **zellij/** — Zellij terminal workspace (KDL config + `zas` session-picker helper)
-- **ghostty/config** — Ghostty terminal settings
-- **starship.toml** — Starship prompt config (loaded via `STARSHIP_CONFIG` in .zshrc)
-- **lazygit/config.yml** — Lazygit TUI config
+- **nvim/** - Neovim config (Lua-based, lazy.nvim plugin manager); keybinding reference in `nvim/KEYMAPS.md`
+- **zsh/.zshrc** - Zsh shell config (Oh My Zsh, Starship prompt, modern CLI tools)
+- **zellij/** - Zellij terminal workspace (KDL config + `zas` session-picker helper)
+- **ghostty/config** - Ghostty terminal settings
+- **starship.toml** - Starship prompt config (loaded via `STARSHIP_CONFIG` in .zshrc)
+- **lazygit/config.yml** - Lazygit TUI config
 
 ## Neovim Architecture
 
 Entry point: `nvim/init.lua` → requires `lua/init.lua` (settings, keymaps, diagnostics).
 
-Plugin system uses **lazy.nvim** (auto-bootstraps in `lua/plugins.lua`). `lua/plugins/plugins_list.lua` is a spec list only — any plugin config longer than a few lines lives in its own file under `lua/plugins/` (blink, snacks, treesitter, tokyonight, conform, diffview, gitsigns, lualine; keep it that way). The DAP config (`lua/plugins/nvim-dap.lua`) is loaded separately from `init.lua`.
+Plugin system uses **lazy.nvim** (auto-bootstraps in `lua/plugins.lua`). `lua/plugins/plugins_list.lua` is a spec list only - any plugin config longer than a few lines lives in its own file under `lua/plugins/` (blink, snacks, treesitter, tokyonight, conform, diffview, gitsigns, lualine; keep it that way). The DAP config (`lua/plugins/nvim-dap.lua`) is loaded separately from `init.lua`.
 
 Key plugin consolidation (2026 update):
 - **snacks.nvim** replaces telescope, nvim-tree, toggleterm, dressing, nvim-notify
@@ -27,12 +29,12 @@ Key plugin consolidation (2026 update):
 - **lualine.nvim** replaces galaxyline
 
 Custom modules:
-- **lua/codex_agent.lua** — Codex CLI integration: terminal split (`codex --no-alt-screen`), prompts from visual selection, and an inline visual-review mode (extmark-rendered hunks with accept/reject). Keymaps under `<leader>a*` / `<leader>c*`.
-- **lua/private/** (gitignored) — machine-local / private config overlay, loaded last from `nvim/init.lua` via `pcall` (absent on fresh clones). Anything tied to private/work repos — project tooling, extra LSP schemas (merged via `vim.lsp.config`), keymaps — goes here, NEVER in tracked files.
+- **lua/codex_agent.lua** - Codex CLI integration: terminal split (`codex --no-alt-screen`), prompts from visual selection, and an inline visual-review mode (extmark-rendered hunks with accept/reject). Keymaps under `<leader>a*` / `<leader>c*`.
+- **lua/private/** (gitignored) - machine-local / private config overlay, loaded last from `nvim/init.lua` via `pcall` (absent on fresh clones). Anything tied to private/work repos - project tooling, extra LSP schemas (merged via `vim.lsp.config`), keymaps - goes here, NEVER in tracked files.
 
-LSP configs: `lua/lsp.lua` — always: lua_ls, clangd, digestif; rust_analyzer via ra-multiplex with plain-rust-analyzer fallback; if installed: bashls, dockerls, ruff, basedpyright/pyright, yamlls.
+LSP configs: `lua/lsp.lua` - always: lua_ls, clangd, digestif; rust_analyzer via ra-multiplex with plain-rust-analyzer fallback; if installed: bashls, dockerls, ruff, basedpyright/pyright, yamlls.
 Formatting: conform.nvim with format-on-save (clang-format, rustfmt, dart_format, prettierd/prettier, stylua, ruff, shfmt); stylua config in `nvim/.stylua.toml`.
-DAP: `lua/plugins/nvim-dap.lua` (lldb-dap for Rust, Flutter via FVM with multi-flavor support; reads `FLUTTER_PATH`/`DART_PATH` from the shell env). Treat this file as hands-off — the Flutter debug setup is hard-won.
+DAP: `lua/plugins/nvim-dap.lua` (lldb-dap for Rust, Flutter via FVM with multi-flavor support; reads `FLUTTER_PATH`/`DART_PATH` from the shell env). Treat this file as hands-off - the Flutter debug setup is hard-won.
 
 After changing keymaps, update `nvim/KEYMAPS.md` to match.
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,68 @@
 <h3 align="center">Dotfiles</h3>
 
-Personal macOS dotfiles — source-based: tools read their configs straight from `~/dotfiles/`, no symlink farm, no install scripts.
+Personal macOS dotfiles. Tools read their configs directly from `~/dotfiles/`, so there is no install script and almost nothing to symlink. Setup is a `git clone` and two symlinks.
 
-### Stack
+<!--
+Screenshots: drop PNGs into assets/ and uncomment.
 
-- Terminal: [Ghostty](https://ghostty.org)
-- Editor: [Neovim](https://neovim.io) — keybinding reference in [`nvim/KEYMAPS.md`](nvim/KEYMAPS.md)
-- Shell: Zsh ([Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh)) + [Starship](https://starship.rs) prompt
-- Terminal workspace: [Zellij](https://zellij.dev)
-- Git TUI: [Lazygit](https://github.com/jesseduffield/lazygit)
-- Modern CLI: eza · bat · zoxide · atuin · delta
+<p align="center">
+  <img src="assets/terminal.png" width="90%" alt="Ghostty running Zellij with the Starship prompt">
+</p>
+<p align="center">
+  <img src="assets/nvim.png" width="90%" alt="Neovim">
+</p>
+-->
 
-### Layout
+## What's inside
 
-| Path | What |
-|------|------|
-| `nvim/` | Neovim — lazy.nvim, snacks, blink.cmp, LSP/DAP, Codex integration |
-| `zsh/.zshrc` | Shell setup, PATHs, aliases |
-| `zellij/` | Zellij config + `zas` session picker |
-| `ghostty/config` | Terminal settings |
-| `starship.toml` | Prompt |
-| `lazygit/config.yml` | Lazygit |
+| Path | Tool | Role |
+|------|------|------|
+| `nvim/` | [Neovim](https://neovim.io) | Editor. Lua config on lazy.nvim, LSP and debugging for Dart/Flutter, Rust, C++ and LaTeX, plus a custom [Codex CLI](https://github.com/openai/codex) integration. Details in [`nvim/README.md`](nvim/README.md), all keybindings in [`nvim/KEYMAPS.md`](nvim/KEYMAPS.md) |
+| `zsh/.zshrc` | Zsh | Shell config: PATH setup, aliases, plugins ([Oh My Zsh](https://ohmyz.sh), zsh-vi-mode) |
+| `ghostty/config` | [Ghostty](https://ghostty.org) | Terminal emulator settings (font, theme, keybinds) |
+| `zellij/` | [Zellij](https://zellij.dev) | Terminal multiplexer: tabs, panes and detachable sessions inside one terminal window. `zas` is a small helper that lists sessions and attaches to the one you pick |
+| `starship.toml` | [Starship](https://starship.rs) | Shell prompt (git status, language versions, command duration) |
+| `lazygit/config.yml` | [Lazygit](https://github.com/jesseduffield/lazygit) | Terminal UI for git |
 
-For some detailed information, you can check out my post
-[My environment setup for Flutter development](https://wiktorzajac.me/posts/flutter-nvim/)
+Everything shares one look: tokyonight-storm colors across Ghostty, Neovim, Zellij and Starship.
+
+## Replaced classics
+
+`.zshrc` swaps a few standard commands for modern equivalents. If you don't know these tools, each one is worth a look on its own:
+
+| Instead of | Using | What you gain |
+|------------|-------|---------------|
+| `ls` | [eza](https://github.com/eza-community/eza) | colors, icons, a git-status column, `lt` for a tree view |
+| `cat` | [bat](https://github.com/sharkdp/bat) | syntax highlighting and line numbers |
+| `cd` between projects | [zoxide](https://github.com/ajeetdsouza/zoxide) | `z dot` jumps to `~/dotfiles` from anywhere; it remembers the directories you actually use |
+| `Ctrl-R` history search | [atuin](https://atuin.sh) | full-text searchable shell history in SQLite, optionally synced between machines |
+| `git diff` pager | [delta](https://github.com/dandavison/delta) | side-by-side, syntax-highlighted diffs (git config snippet in the comments of `.zshrc`) |
+
+## Setup
+
+Clone to `~/dotfiles` (paths assume this location) and link the two configs that need linking:
+
+```sh
+git clone https://github.com/wzslr321/dotfiles.git ~/dotfiles
+ln -s ~/dotfiles/zsh/.zshrc ~/.zshrc
+ln -s ~/dotfiles/nvim ~/.config/nvim
+ln -s ~/dotfiles/ghostty/config ~/Library/'Application Support'/com.mitchellh.ghostty/config
+```
+
+Zellij, Starship and the rest need no linking; `.zshrc` points them at the repo through `ZELLIJ_CONFIG_DIR` and `STARSHIP_CONFIG`.
+
+The tools themselves come from Homebrew:
+
+```sh
+brew install neovim zellij starship lazygit eza bat zoxide atuin git-delta
+```
+
+Neovim installs its plugins automatically on first start.
+
+## Private config
+
+Anything machine-specific or tied to private repos stays out of git, in overlays that load automatically when present:
+
+- `~/.zshenv.local`, secrets and tokens, sourced first
+- `zsh/.zshrc.local`, machine-local shell config, sourced last
+- `nvim/lua/private/`, local Neovim config (project tooling, extra LSP schemas), loaded last from `init.lua`

--- a/ghostty/config
+++ b/ghostty/config
@@ -20,3 +20,4 @@ cursor-style-blink = false
 
 keybind = ctrl+z=close_surface
 keybind = ctrl+d=new_split:right
+keybind = shift+enter=text:\n

--- a/nvim/KEYMAPS.md
+++ b/nvim/KEYMAPS.md
@@ -9,7 +9,7 @@ AI-Provenance:
 Personal keybinding reference, generated from the live config (2026-07).
 
 - **Leader** = `Space`
-- **Local leader** = `'` (apostrophe — used by LaTeX/vimtex)
+- **Local leader** = `'` (apostrophe - used by LaTeX/vimtex)
 - Text objects work after an operator (`d`, `c`, `y`, `v`). Below, `<leader>` = `Space`.
 
 ---
@@ -29,7 +29,7 @@ Personal keybinding reference, generated from the live config (2026-07).
 | `<leader>lg` | Lazygit |
 | `<leader>?` | Buffer-local keymaps (which-key popup) |
 
-## LSP — code intelligence
+## LSP - code intelligence
 
 Neovim 0.11 built-in defaults + a few custom maps.
 
@@ -50,7 +50,7 @@ Neovim 0.11 built-in defaults + a few custom maps.
 | `<leader>ih` | Toggle inlay hints (inline types & param names) |
 
 > Formatting also runs **on save**. Toggle with `:FormatDisable` / `:FormatEnable` (`:FormatDisable!` = current buffer only).
-> `gr` overlaps the `gr…` LSP prefix — after a brief `timeoutlen` pause `gr` opens Trouble; type `grr` quickly for the built-in.
+> `gr` overlaps the `gr…` LSP prefix - after a brief `timeoutlen` pause `gr` opens Trouble; type `grr` quickly for the built-in.
 
 ## Diagnostics
 
@@ -59,11 +59,11 @@ Neovim 0.11 built-in defaults + a few custom maps.
 | `]d` / `[d` | Next / prev diagnostic |
 | `<C-w>d` | Show diagnostics under cursor |
 | `<leader>gl` | Diagnostic float *(custom)* |
-| `<leader>xa` | Toggle diagnostics (workspace) — Trouble |
-| `<leader>xw` | Open diagnostics — Trouble |
-| `<leader>xd` | Buffer diagnostics — Trouble |
-| `<leader>xq` | Quickfix list — Trouble |
-| `<leader>xl` | Location list — Trouble |
+| `<leader>xa` | Toggle diagnostics (workspace) - Trouble |
+| `<leader>xw` | Open diagnostics - Trouble |
+| `<leader>xd` | Buffer diagnostics - Trouble |
+| `<leader>xq` | Quickfix list - Trouble |
+| `<leader>xl` | Location list - Trouble |
 
 ## Git
 
@@ -81,12 +81,12 @@ gitsigns (in-buffer) + diffview + lazygit. `git-messenger` is also installed for
 | `<leader>hd` | Diff this |
 | `<leader>htb` | Toggle inline line-blame |
 | `<leader>htd` | Toggle deleted |
-| `<leader>gd` | Diffview — review full working-tree diff |
-| `<leader>gD` | Diffview — current file only |
-| `<leader>gq` | Diffview — close review |
+| `<leader>gd` | Diffview - review full working-tree diff |
+| `<leader>gD` | Diffview - current file only |
+| `<leader>gq` | Diffview - close review |
 | `<leader>lg` | Lazygit (full TUI) |
 
-## Treesitter — selection & movement
+## Treesitter - selection & movement
 
 | Key | Action |
 |-----|--------|
@@ -101,8 +101,8 @@ mini.ai (treesitter-powered) + built-ins.
 
 | Object | Meaning |
 |--------|---------|
-| `af` / `if` | Function — outer / inner |
-| `ac` / `ic` | Class — outer / inner |
+| `af` / `if` | Function - outer / inner |
+| `ac` / `ic` | Class - outer / inner |
 | `aa` / `ia` | Argument / parameter |
 | `a)` `a]` `a}` `a"` `a'` `` a` `` | Brackets / quotes (use `i` for inner) |
 | `at` / `it` | Tag (HTML/XML) |
@@ -113,15 +113,15 @@ mini.ai (treesitter-powered) + built-ins.
 
 | Key | Action |
 |-----|--------|
-| `gc` / `gcc` | Toggle comment — motion / current line |
+| `gc` / `gcc` | Toggle comment - motion / current line |
 | `sa` | Add surrounding (`saiw)` or visual `sa)`) |
 | `sd` | Delete surrounding |
 | `sr` | Replace surrounding |
-| `sf` / `sF` | Find surrounding — right / left |
+| `sf` / `sF` | Find surrounding - right / left |
 | `sh` | Highlight surrounding |
-| — | `(` `[` `{` `"` `'` `` ` `` auto-close (mini.pairs) |
+| - | `(` `[` `{` `"` `'` `` ` `` auto-close (mini.pairs) |
 
-## Completion — blink.cmp (insert mode, `super-tab` preset)
+## Completion - blink.cmp (insert mode, `super-tab` preset)
 
 | Key | Action |
 |-----|--------|
@@ -134,7 +134,7 @@ mini.ai (treesitter-powered) + built-ins.
 
 > Ghost text previews the top match inline; function signature help pops up while typing call arguments.
 
-## Debugging — DAP
+## Debugging - DAP
 
 | Key | Action |
 |-----|--------|
@@ -156,19 +156,19 @@ mini.ai (treesitter-powered) + built-ins.
 | `<leader>ri` / `<leader>rj` | Horizontal resize + / − |
 | `<C-w>h/j/k/l` *(in terminal)* | Leave terminal → move to window |
 | `<Esc>` *(in terminal)* | Exit terminal mode |
-| `<leader>dd` | Detour — open current buffer in a float |
+| `<leader>dd` | Detour - open current buffer in a float |
 
 ## Codex (`lua/codex_agent.lua`)
 
 | Key | Action |
 |-----|--------|
-| `<leader>a?` | Action menu — normal mode; in visual mode includes the selection |
+| `<leader>a?` | Action menu - normal mode; in visual mode includes the selection |
 | `<leader>ac` | Open / focus Codex terminal |
 | `<leader>ar` | Resume last Codex session (`codex resume --last`) |
 | `<leader>ab` | Send current buffer path to Codex |
 | `<leader>as` *(visual)* | Ask Codex about selection (starts inline visual review) |
 | `<leader>av` | `codex review` |
-| `<leader>aa` | `codex apply` — apply latest Codex diff |
+| `<leader>aa` | `codex apply` - apply latest Codex diff |
 | `<leader>ad` | Review Codex/git changes (Diffview) |
 
 **Inline visual review** (active after `<leader>as`; refreshes on focus-gain):
@@ -182,7 +182,7 @@ mini.ai (treesitter-powered) + built-ins.
 
 **Inside the Codex terminal:** `<C-s>` scroll mode · `q` back to input · `<C-g>` focus reviewed file.
 
-## LaTeX — vimtex (local leader `'`)
+## LaTeX - vimtex (local leader `'`)
 
 | Key | Action |
 |-----|--------|

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -1,7 +1,17 @@
-## Neovim config
+# Neovim config
 
-Lua config built on lazy.nvim. Entry point: `init.lua` → `lua/init.lua` (options, autocmds) → plugins, LSP, DAP, keymaps.
+Lua config built on lazy.nvim. `init.lua` loads `lua/init.lua` (options, diagnostics), then plugins, LSP, DAP and keymaps.
 
-Highlights: snacks.nvim (picker / explorer / terminal), blink.cmp, treesitter, conform format-on-save, and a custom Codex CLI integration (`lua/codex_agent.lua`) with inline visual review of AI edits.
+`lua/plugins/plugins_list.lua` is only a list of specs. Any plugin that needs more than a few lines of setup gets its own file under `lua/plugins/`.
+
+Highlights:
+
+- snacks.nvim: picker, file explorer, terminal, lazygit
+- blink.cmp completion (super-tab preset) and treesitter
+- conform.nvim format-on-save (toggle with `:FormatDisable`)
+- LSP and debugging for Dart/Flutter, Rust, C++, Lua and LaTeX
+- `lua/codex_agent.lua`: Codex CLI in a terminal split, prompts from visual selection, inline review of AI edits with per-hunk accept/reject
+
+Machine-local or private additions go in `lua/private/` (gitignored, loaded last when present).
 
 Keybinding reference: [KEYMAPS.md](KEYMAPS.md).

--- a/nvim/lua/keymappings.lua
+++ b/nvim/lua/keymappings.lua
@@ -43,7 +43,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
             map("n", "K", vim.lsp.buf.hover, vim.tbl_extend("force", opts, { desc = "Hover docs" }))
         end
 
-        -- inlay hints (inline types & param names) — deterministic LSP info, not AI
+        -- inlay hints (inline types & param names) - deterministic LSP info, not AI
         if client and client:supports_method("textDocument/inlayHint") then
             vim.lsp.inlay_hint.enable(true, { bufnr = ev.buf })
             map("n", "<space>ih", function()

--- a/nvim/lua/plugins/plugins_list.lua
+++ b/nvim/lua/plugins/plugins_list.lua
@@ -1,4 +1,4 @@
--- Plugin list — specs only. Any plugin whose config is more than a few
+-- Plugin list - specs only. Any plugin whose config is more than a few
 -- lines lives in its own file under lua/plugins/ (nvim-dap.lua is loaded
 -- separately from init.lua).
 return {

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -49,7 +49,7 @@ export DOTFILES="$HOME/dotfiles"
 export ZELLIJ_CONFIG_DIR="$DOTFILES/zellij/"
 source "$DOTFILES/zellij/.zellij.conf"
 
-# --- Oh My Zsh (no theme — starship handles the prompt) ---
+# --- Oh My Zsh (no theme - starship handles the prompt) ---
 export ZSH="$HOME/.oh-my-zsh"
 ZSH_THEME=""
 plugins=(git zsh-vi-mode)
@@ -111,8 +111,10 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
 
 # --- Atuin (shell history) ---
-. "$HOME/.atuin/bin/env"
-eval "$(atuin init zsh)"
+if [ -f "$HOME/.atuin/bin/env" ]; then
+    . "$HOME/.atuin/bin/env"
+fi
+command -v atuin >/dev/null && eval "$(atuin init zsh)"
 
 # --- Zoxide (smart cd, replaces cd) ---
 # Install: brew install zoxide


### PR DESCRIPTION
Follow-up to #9, based on review feedback:

- README rewritten: setup instructions that actually work on a fresh machine, every tool explained instead of name-dropped, commented screenshot placeholders under `assets/`, dead blog link removed (domain expired)
- em dashes removed from every tracked file, docs-style note added to CLAUDE.md
- ghostty: `shift+enter` newline keybind was only in the live config, now captured in the repo
- zshrc: atuin init guarded so the shell still starts on a machine without it

Screenshots land in a follow-up commit once available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)